### PR TITLE
[fix] Disable script_hash for fingerprint-strings

### DIFF
--- a/engines/nmap/engine-nmap.py
+++ b/engines/nmap/engine-nmap.py
@@ -479,7 +479,11 @@ def _parse_report(filename, scan_id):
                 for port_script in port.findall('script'):
                     script_id = port_script.get('id')
                     script_output = port_script.get('output')
-                    script_hash = hashlib.sha1(script_output).hexdigest()[:6]
+                    # Disable hash for some script_id
+                    if script_id in ["fingerprint-strings"]:
+                       script_hash = "None"
+                    else:
+                        script_hash = hashlib.sha1(script_output).hexdigest()[:6]
 
                     if script_id == "vulners":
                         port_max_cvss, port_cve_list, port_cve_links, port_cpe = _get_vulners_findings(script_output)


### PR DESCRIPTION
fingerprint-strings has a too random output to be a unique hash. It causes multiple findings and this is not relevant.