### PR TITLE
openvas: fix create target hosts

### DIFF
--- a/engines/openvas/engine-openvas.py
+++ b/engines/openvas/engine-openvas.py
@@ -158,7 +158,7 @@ def create_target(
     """
     new_target_xml = this.gmp.create_target(
         target_name,
-        hosts=target_name,
+        hosts=target_name.split(),
         ssh_credential_id=ssh_credential_id,
         ssh_credential_port=ssh_credential_port,
         smb_credential_id=smb_credential_id,


### PR DESCRIPTION
This must be a list, or the string is splitted by gmp
in a list of characters :/

ex:
fqdn: aderke1.odiso.net

become in target hosts : "a, d, e, r, k, 1, ., o, i, s, n, t"