### PR TITLE
Virustotal ratelimiter & logs

### DIFF
--- a/engines/virustotal/engine-virustotal.py
+++ b/engines/virustotal/engine-virustotal.py
@@ -675,7 +675,7 @@ def _parse_results(scan_id):
                                 "title": "URL scan for '{}' detected at least 1 positive match (Score: {}/{}, HASH: {})".format(
                                     record["url"], record["report"]["results"]["positives"], record["report"]["results"]["total"], url_hash),
                                 "description": "URL report for '{}' stated at least 1 positive match ({}/{}):\n\n{}".format(
-                                    record["url"], record["report"]["results"]["positives"], record["report"]["results"]["total"], record["url"]),
+                                    record["url"], record["report"]["results"]["positives"], record["report"]["results"]["total"], record["report"]["results"]["permalink"]),
                                 "solution": "n/a",
                                 "metadata": {"tags": ["url"], "links": [record["report"]["results"]["permalink"]]},
                                 "type": "vt_url_positivematch",

--- a/engines/virustotal/engine-virustotal.py
+++ b/engines/virustotal/engine-virustotal.py
@@ -672,8 +672,8 @@ def _parse_results(scan_id):
                                 "issue_id": len(issues)+1,
                                 "severity": "high", "confidence": "certain",
                                 "target": {"addr": [asset], "protocol": "url"},
-                                "title": "URL scan for '{}' detected at least 1 positive match (Score: {}/{}, HASH: {})".format(
-                                    record["url"], record["report"]["results"]["positives"], record["report"]["results"]["total"], url_hash),
+                                "title": "URL scan detected at least 1 positive match (Score: {}/{}, HASH: {})".format(
+                                    record["report"]["results"]["positives"], record["report"]["results"]["total"], url_hash),
                                 "description": "URL report for '{}' stated at least 1 positive match ({}/{}):\n\n{}".format(
                                     record["url"], record["report"]["results"]["positives"], record["report"]["results"]["total"], record["report"]["results"]["permalink"]),
                                 "solution": "n/a",


### PR DESCRIPTION
**Features**:
  - Replace log by native werkzeug logs
  - Implement ratelimiter for apikeys. It's mostly a retrier and sleeps if every apikeys fails
  - Scan every domain's detected_url

**Fixtures**:
  - Decode user options with more options ("UTF-8", "ignore")
  - Load user options until it's a dict
  - Look for "scan_url" instead of "scan_ip" for URL scan