### PR TITLE
Openvas : add netaddr as dependency

### DIFF
--- a/engines/openvas/requirements.txt
+++ b/engines/openvas/requirements.txt
@@ -27,3 +27,4 @@ six==1.12.0
 tomlkit==0.5.11
 urllib3==1.25.2
 Werkzeug==1.0.1
+netaddr==0.7.19                          


### PR DESCRIPTION
Add netaddr as dependency, docker container won't start without netaddr.
