### PR TITLE
Add reason message if openVAS initialization failed

### DIFF
--- a/engines/openvas/README.md
+++ b/engines/openvas/README.md
@@ -1,19 +1,24 @@
 ## Description
-Openvas REST API engine
+Openvas REST API engine\
+v1.1.0-beta1
 
 ## Dependencies
 - Python 3 + pip
 - See requirements.txt for others python packages (use "pip install -r requirements.txt")
-- Install Python-gvm
+- Install Python-gvm\
   `mkdir -p libs ; cd libs ; git clone git://github.com/greenbone/python-gvm ; pip3 install -e python-gvm`
 - You have to create a new task on OpenVAS and configure the task_id in openvas.json
-- OpenVAS instance. Ex: docker run -d -p 443:443 -p 9390:9390 -e PUBLIC_HOSTNAME=<my_hostname> --name openvas mikesplain/openvas
+- OpenVAS instance. \
+  Eg: `docker run -d -p 443:443 -p 9390:9390 -e PUBLIC_HOSTNAME=<my_hostname> --name openvas mikesplain/openvas`
 
 ## Testing URLs
 
 ```bash
 OPENVAS_ENGINE_URL=http://patrowl-900.domain.net:5016/engines/openvas
 ASSET_FQDN=patrowl.io
+
+# Engine status
+curl "${OPENVAS_ENGINE_URL}"/info
 
 # Start scan
 curl "${OPENVAS_ENGINE_URL}"/startscan -XPOST -H 'Accept: application/json' -H 'Content-type: application/json' -d "{\"scan_id\": 1, \"options\": {\"enable_create_task\": \"False\", \"enable_create_target\": \"False\", \"enable_start_task\": \"False\"}, \"assets\": [{\"datatype\": \"domain\", \"criticity\": \"medium\", \"id\": 1, \"value\": \"$ASSET_FQDN\"}], \"engine_id\": 9}"

--- a/engines/openvas/openvas.json.sample
+++ b/engines/openvas/openvas.json.sample
@@ -1,11 +1,12 @@
 {
   "name": "Openvas API",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Openvas API",
   "allowed_asset_types": ["fqdn" ,"ip", "domain", "ip-subnet", "ip-range", "url"],
   "options": {
-     "gmp_host":         { "type": "required", "value": "www.openvas.com"},
+     "gmp_host":         { "type": "required", "value": "127.0.0.1"},
      "gmp_port":         { "type": "optional", "value": "9390"},
+     "timeout":          2,
      "gmp_username":     { "type": "optional", "value": "admin"},
      "gmp_password":     { "type": "optional", "value": "admin"},
      "default_credential_name":  { "type": "optional", "value": "SSH Scanner"},


### PR DESCRIPTION
in accordance with #66 some additional information is needed when openVAS calls failed.
Default connection timeout is set to 5 seconds but can be overwriten in config file


