### PR TITLE
[virustotal] Fix missing key in report

### DIFF
--- a/engines/virustotal/engine-virustotal.py
+++ b/engines/virustotal/engine-virustotal.py
@@ -670,7 +670,7 @@ def _parse_results(scan_id):
                     for record in sorted(results['detected_urls'], key=operator.itemgetter('url')):
                         entry = "{} (total: {}, scan date: {})".format(record['url'], record['total'], record['scan_date'])
                         detected_url_str = "".join((detected_url_str, entry+"\n"))
-                        if "positives" in record["report"]["results"] and record["report"]["results"]["positives"] > 0:
+                        if "results" in record["report"] and "positives" in record["report"]["results"] and record["report"]["results"]["positives"] > 0:
                             url_hash = hashlib.sha1(str(record["url"]).encode('utf-8')).hexdigest()[:6]
                             nb_vulns['high'] += 1
                             issues.append({


### PR DESCRIPTION
**Fixtures**:
  - Sometimes, the "results" key is missing from record["report"]. A check is done to avoid a crash (HTTP code 500)