### PR TITLE
[wpscan] 1.0.2: Add environ var for APP_MAXPROCS & fix missing proc

### DIFF
--- a/engines/wpscan/wpscan.json.sample
+++ b/engines/wpscan/wpscan.json.sample
@@ -1,6 +1,6 @@
 {
   "name": "Wpscan API",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Wpscan API",
   "allowed_asset_types": ["fqdn", "ip", "domain", "url"],
   "options": {


### PR DESCRIPTION
Ability to add an env var to set the APP_MAXPROCS arg

Missing proc issue during first status
```
File "/opt/PatrowlEngines/engines/wpscan/env3/lib/python3.7/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/PatrowlEngines/engines/wpscan/env3/lib/python3.7/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/opt/PatrowlEngines/engines/wpscan/engine-wpscan.py", line 173, in status_scan
    proc = engine.scans[scan_id]["reports"][asset]["proc"]
KeyError: 'proc'
```
