### PR TITLE
Fix "Nessus Scan Information" plugin scan information

### DIFF
--- a/engines/nessus/parser.py
+++ b/engines/nessus/parser.py
@@ -135,7 +135,7 @@ def parse_report(report_filename, nessus_prefix, resolvefqdn=False):
 
                                 if param.tag == 'plugin_output':
                                     finding['raw'] = param.text
-                                    plugin_output = str(re.sub('\nDate:.*\n', '\n', str(param.text)))
+                                    plugin_output = str(re.sub('Scan Start Date:.*\n', '\n', str(param.text)))
                                     finding['description'] = finding['description'] + "\n\nScanner output:\n\n" + plugin_output
 
                             finding_hash = hashlib.sha1(str(finding['description']).encode("utf-8")).hexdigest()[:6]


### PR DESCRIPTION
Nessus `Nessus Scan Information` plugin returns `Scan Start Date :` in its nessus file `plugin_output` tag, not `Date :`.

![image](https://user-images.githubusercontent.com/11051803/111345094-3dc09f80-867d-11eb-9262-5fbd3bc1edab.png)

