### PR TITLE
Fix pip21 support drop for Python3.5 in Dockerfile

### DIFF
--- a/engines/arachni/Dockerfile
+++ b/engines/arachni/Dockerfile
@@ -25,7 +25,7 @@ COPY README.md .
 
 WORKDIR /opt/patrowl-engines/arachni/libs
 
-RUN apt-get -qq update && apt-get install -yq wget ruby bash python3 curl bsdtar make gcc && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get -qq update && apt-get install -yq wget ruby bash python3 python3-dev curl bsdtar make gcc && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN curl -fsSL -o- https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3.5
 RUN ln -sf $(which bsdtar) $(which tar)
 RUN wget $DL_ARACHNI_LINK -nv

--- a/engines/arachni/Dockerfile
+++ b/engines/arachni/Dockerfile
@@ -25,7 +25,8 @@ COPY README.md .
 
 WORKDIR /opt/patrowl-engines/arachni/libs
 
-RUN apt-get -qq update && apt-get install -yq wget ruby bash python3 python3-pip bsdtar make gcc && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get -qq update && apt-get install -yq wget ruby bash python3 curl bsdtar make gcc && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN curl -fsSL -o- https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3.5
 RUN ln -sf $(which bsdtar) $(which tar)
 RUN wget $DL_ARACHNI_LINK -nv
 RUN tar xzf $TGZ_ARACHNI && \


### PR DESCRIPTION
Fix docker build error by installing pip>21 since it breaks compatibility with Python3.5