### PR TITLE
Update ruby version

### DIFF
--- a/engines/wpscan/Dockerfile
+++ b/engines/wpscan/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.1-alpine AS builder
+FROM ruby:3.0.2-alpine AS builder
 
 # ENV WP_VERSION v3.8.7
 ENV WP_VERSION v3.8.13
@@ -24,7 +24,7 @@ RUN rake install --trace
 RUN chmod -R a+r /usr/local/bundle
 
 # -- WPScan Deployment
-FROM ruby:2.7.1-alpine
+FROM ruby:3.0.2-alpine
 LABEL Name="WPScan\ \(Patrowl engine\)" Version="1.4.27"
 
 RUN adduser -h /wpscan -g WPScan -D wpscan


### PR DESCRIPTION
Hi!

I open this PR because I find a bug in the WPScan docker. 

This bug appears when we launch WPScan in a docker. We can see this error: "Report file is not a valid json" during this request: /engines/wpscan/get findings. The file is empty because Wpscan has a segmentation fault. 

<img width="860" alt="BUG_Ruby_Wpscan" src="https://user-images.githubusercontent.com/94525580/143476390-eaf61785-5e49-45cd-87c6-86fa08b3513f.png">

To resolve this bug, I modified the image in the dockerfile. 

Best regards 

Marius

 
